### PR TITLE
Fix allpos file to only contain the input structure once

### DIFF
--- a/pymuonsuite/muairss.py
+++ b/pymuonsuite/muairss.py
@@ -276,7 +276,7 @@ def save_muairss_collection(struct, params, batch_path=''):
     # Do we also save a collective structure?
     allf = params['allpos_filename']
     if allf is not None:
-        alls = struct
+        alls = struct.copy()
         csp = struct.get_chemical_symbols()
         for atoms in dc:
             # We rely on the fact the muon is always put at the end

--- a/pymuonsuite/muairss.py
+++ b/pymuonsuite/muairss.py
@@ -276,7 +276,15 @@ def save_muairss_collection(struct, params, batch_path=''):
     # Do we also save a collective structure?
     allf = params['allpos_filename']
     if allf is not None:
-        alls = sum(dc.structures, struct)
+        alls = struct
+        csp = struct.get_chemical_symbols()
+        for atoms in dc:
+            # We rely on the fact the muon is always put at the end
+            mu = atoms[-1]
+            alls.append(mu)
+            csp += [params['mu_symbol']]
+
+        alls.set_array('castep_custom_species', np.array(csp))
         io.write(allf, alls)
 
 


### PR DESCRIPTION
Currently, the output file generated with all positions of the muons contains the strucuture+muon every time, and then also adds on the structure. Additionally, when it adds on the structure it loses the names of the elements - it has them all as '0', which then can't be read (but all of the structure+muons are fine).
This change ensures the structure is only output once and the element names are not lost.