### PR TITLE
minor fix for pm-muairrs when uep_chden is not given

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ examples/quantum/*
 docs/*
 !docs/*.md
 !docs/Makefile
+
+# Pycharm
+.idea/*

--- a/pymuonsuite/io/uep.py
+++ b/pymuonsuite/io/uep.py
@@ -85,9 +85,13 @@ class UEPCalculator(object):
         self.index = index
         self.path = path
 
-        chden = os.path.abspath(chden)
-        chpath, chname = os.path.split(chden)
-        chseed = os.path.splitext(chname)[0]
+        if chden != "":
+            chden = os.path.abspath(chden)
+            chpath, chname = os.path.split(chden)
+            chseed = os.path.splitext(chname)[0]
+        else:
+            chpath = os.path.abspath("")
+            chseed = ""
 
         self.chden_path = chpath
         self.chden_seed = chseed


### PR DESCRIPTION
Resolved #55

Simple fix where I add an edge case to account for `chden` being empty which wasn't done before