### PR TITLE
Make sure copied scripts always use LF

### DIFF
--- a/pymuonsuite/io/castep.py
+++ b/pymuonsuite/io/castep.py
@@ -214,9 +214,9 @@ class ReadWriteCastep(ReadWrite):
             )
 
             if self.script is not None:
-                stxt = open(self.script).read()
+                stxt = open(self.script, newline="").read()
                 stxt = stxt.format(seedname=sname)
-                with open(os.path.join(folder, "script.sh"), "w") as sf:
+                with open(os.path.join(folder, "script.sh"), "w", newline="") as sf:
                     sf.write(stxt)
         else:
             raise (

--- a/pymuonsuite/io/castep.py
+++ b/pymuonsuite/io/castep.py
@@ -214,9 +214,9 @@ class ReadWriteCastep(ReadWrite):
             )
 
             if self.script is not None:
-                stxt = open(self.script, newline="").read()
+                stxt = open(self.script).read()
                 stxt = stxt.format(seedname=sname)
-                with open(os.path.join(folder, "script.sh"), "w", newline="") as sf:
+                with open(os.path.join(folder, "script.sh"), "w", newline="\n") as sf:
                     sf.write(stxt)
         else:
             raise (

--- a/pymuonsuite/test/test_data/Si2/submit_Si2_geom_opt.sh
+++ b/pymuonsuite/test/test_data/Si2/submit_Si2_geom_opt.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+#SBATCH -o %J.o
+#SBATCH -e %J.e
+#SBATCH -t 24:00:00
+#SBATCH -n 16
+#SBATCH --job-name= Si2_geom_opt
+#SBATCH --exclusive
+module load castep/19
+mpirun castep.mpi Si2_geom_opt


### PR DESCRIPTION
Fixes #34.

Assumes the script is always destined for a UNIX system even if it was originally drafted on Windows. (In the case of CASTEP, this is probably true)