### PR TITLE
Update spglib to use available wheels

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Collection of scripts and utilities for muon spectroscopy.
 
 Requires Python 3.7+. Install with pip or conda:
 
-`pip install pymuonsuite` (less recommended on Windows machines)
+`pip install pymuonsuite`
 
 `conda install pymuonsuite`
 
@@ -25,7 +25,8 @@ On some platforms, additional tools are needed to build the `spglib` Python modu
 via pip. On Windows, you may need to install
 [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/); on Linux
 you may need to `apt-get install python-dev` or `yum install python-devel` according to your
-distribution. This should not be necessary if installing via conda.
+distribution. This should not be necessary if installing via conda, and so we recommend using 
+conda if you want to avoid installing these tools.
 
 Further help with Spglib installation can be found in the
 [Spglib documentation](https://spglib.github.io/spglib/python-spglib.html#installation).

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ seekpath==2.0.1
 setuptools-scm==6.3.2
 six==1.16.0
 Soprano==0.8.13
-spglib==1.16.1
+spglib==2.0.0
 threadpoolctl==3.0.0
 tomli==1.2.2

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
             "ase>=3.18.1",
             "pyyaml",
             "schema",
-            "spglib>0.8",
+            "spglib>2.0.0",
             "soprano>=0.8.11",
             "parse-fmt>=0.5",
         ],

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
             "ase>=3.18.1",
             "pyyaml",
             "schema",
-            "spglib>=2.0.0",
+            "spglib>0.8",
             "soprano>=0.8.11",
             "parse-fmt>=0.5",
         ],

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
             "ase>=3.18.1",
             "pyyaml",
             "schema",
-            "spglib>2.0.0",
+            "spglib>=2.0.0",
             "soprano>=0.8.11",
             "parse-fmt>=0.5",
         ],


### PR DESCRIPTION
Require spglib==2.0.0 for tests to make sure the newly available wheels work (https://github.com/spglib/spglib/issues/144). Looks like they're fine.

New installs of pymuonsuite via pip should pick up the wheels without any intervention in setup.py (same for older releases) so we shouldn't need to un-recommend the pip install any more.