### PR TITLE
Add build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,24 @@
+name: Build pip wheels
+
+on:
+  push:
+    branches:
+      - main
+      - add-build-action-#75
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build source distribution and wheel
+        run: |
+          python -m pip install build
+          python -m build
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - add-build-action-#75
 
 jobs:
   build_wheels:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 import pathlib
 from setuptools import setup, find_packages
 
-from pymuonsuite import __version__
-
 this_dir = pathlib.Path(__file__).parent
 readme_text = (this_dir / "README.md").read_text()
 
@@ -25,9 +23,13 @@ if __name__ == "__main__":
             os.path.join("data/dftb_pars/", "*"),
         ]
 
+    version = {}
+    with open("pymuonsuite/__init__.py", encoding="utf-8") as fp:
+        exec(fp.read(), version)  # pylint: disable=exec-used
+
     setup(
         name="PyMuonSuite",
-        version=__version__,
+        version=version["__version__"],
         description=("A suite of utilities for muon spectroscopy"),
         long_description=readme_text,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
Adds a minimal pyproject.toml and a build action. Also had to modify how version is obtained in setup.py to match muspinsim as the library cant be imported when using the pyproject.toml.

Closes #75 