### PR TITLE
Add single DOI field to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -60,7 +60,7 @@ keywords:
 license: GPL-3.0
 version: v0.2.3
 date-released: '2022-08-26'
-doi: 10.5281/zenodo.7025643
+doi: 10.5281/zenodo.7025644
 identifiers:
   - type: doi
     value: 10.5281/zenodo.7025643

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -60,6 +60,7 @@ keywords:
 license: GPL-3.0
 version: v0.2.3
 date-released: '2022-08-26'
+doi: 10.5281/zenodo.7025643
 identifiers:
   - type: doi
     value: 10.5281/zenodo.7025643


### PR DESCRIPTION
Changes:
 - APA: `Sturniolo, S., Liborio, L., Chadwick, E., Murgatroyd, L., Laverack, A., Mudaraddi, A., & Muon Spectroscopy Computational Project. (2022). pymuon-suite (Version v0.2.3) [Computer software]. https://github.com/muon-spectroscopy-computational-project/pymuon-suite`
 - BibTeX: 
```BibTeX
@software{Sturniolo_pymuon-suite_2022,
author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and Mudaraddi, Anish and {Muon Spectroscopy Computational Project}},
license = {GPL-3.0},
month = {8},
title = {{pymuon-suite}},
url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
version = {v0.2.3},
year = {2022}
}
```

To:
 - APA: `Sturniolo, S., Liborio, L., Chadwick, E., Murgatroyd, L., Laverack, A., Mudaraddi, A., & Muon Spectroscopy Computational Project. (2022). pymuon-suite (Version v0.2.3) [Computer software]. https://doi.org/10.5281/zenodo.7025643`
 - BibTeX:
```BibTeX
@software{Sturniolo_pymuon-suite_2022,
author = {Sturniolo, Simone and Liborio, Leandro and Chadwick, Eli and Murgatroyd, Laura and Laverack, Adam and Mudaraddi, Anish and {Muon Spectroscopy Computational Project}},
doi = {10.5281/zenodo.7025643},
license = {GPL-3.0},
month = {8},
title = {{pymuon-suite}},
url = {https://github.com/muon-spectroscopy-computational-project/pymuon-suite},
version = {v0.2.3},
year = {2022}
}
```

This is using the "concept" DOI (should resolve to the most recent version of the software). It's also possible to use the specific versioned DOI instead. Undecided on which would be better to use?