### PR TITLE
Use spins from cell instead of castep for UEP #80

### DIFF
--- a/pymuonsuite/calculate/uep/charged.py
+++ b/pymuonsuite/calculate/uep/charged.py
@@ -85,9 +85,13 @@ class ChargeDistribution(object):
         cppot = None
         try:
             with silence_stdio():
-                cppot = io.read(seedpath + ".cell").calc.cell.species_pot.value
+                structure = io.read(seedpath + ".cell")
+                # Use spins from initial cell file rather than CASTEP results
+                initial_spins = structure.get_initial_magnetic_moments()
+                self._struct.set_initial_magnetic_moments(initial_spins)
+                cppot = structure.calc.cell.species_pot.value
         except IOError:
-            pass  # If not available, ignore this
+            print(f"WARNING: cell file {seedpath}.cell not found")
         if cppot is not None:
             ppf = [lpp.split() for lpp in cppot.split("\n") if lpp]
             for el, pppath in ppf:

--- a/pymuonsuite/calculate/uep/charged.py
+++ b/pymuonsuite/calculate/uep/charged.py
@@ -86,9 +86,9 @@ class ChargeDistribution(object):
         try:
             with silence_stdio():
                 structure = io.read(seedpath + ".cell")
-                # Use spins from initial cell file rather than CASTEP results
-                initial_spins = structure.get_initial_magnetic_moments()
-                self._struct.set_initial_magnetic_moments(initial_spins)
+                # Set all spins to 0 rather than use the CASTEP results
+                spins = [0] * len(self._struct.positions)
+                self._struct.set_initial_magnetic_moments(spins)
                 cppot = structure.calc.cell.species_pot.value
         except IOError:
             print(f"WARNING: cell file {seedpath}.cell not found")

--- a/pymuonsuite/calculate/uep/charged.py
+++ b/pymuonsuite/calculate/uep/charged.py
@@ -76,6 +76,9 @@ class ChargeDistribution(object):
         self._elec_den = FMTReader(seedpath + ".den_fmt")
         with silence_stdio():
             self._struct = io.read(seedpath + ".castep")
+            # Set all spins to 0 rather than use the CASTEP results
+            spins = [0] * len(self._struct.positions)
+            self._struct.set_initial_magnetic_moments(spins)
 
         ppots = parse_castep_ppots(seedpath + ".castep")
 
@@ -85,11 +88,7 @@ class ChargeDistribution(object):
         cppot = None
         try:
             with silence_stdio():
-                structure = io.read(seedpath + ".cell")
-                # Set all spins to 0 rather than use the CASTEP results
-                spins = [0] * len(self._struct.positions)
-                self._struct.set_initial_magnetic_moments(spins)
-                cppot = structure.calc.cell.species_pot.value
+                cppot = io.read(seedpath + ".cell").calc.cell.species_pot.value
         except IOError:
             print(f"WARNING: cell file {seedpath}.cell not found")
         if cppot is not None:


### PR DESCRIPTION
When loading for the UEP method, replace the spins from the `castep` file with those from the inital `cell` file. This propogates to the `xyz` files saved in the collection, and then onto the saved structures (if used).

Closes #80