### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.github/workflows/python-package-tests.yml
+++ b/.github/workflows/python-package-tests.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.8", "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Collection of scripts and utilities for muon spectroscopy.
 
 ## Installation
 
-Requires Python 3.7+. Install with pip or conda:
+Requires Python 3.8+. Install with pip or conda:
 
 `pip install pymuonsuite`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ fonttools==4.28.2
 importlib-resources==5.4.0
 kiwisolver==1.3.2
 matplotlib==3.5.0
-numpy==1.21.6; python_version <= "3.7"
-numpy==1.22.0; python_version >= "3.8" and python_version < "4.0"
+numpy==1.22.0
 packaging==21.3
 parse-fmt==0.5.1
 Pillow==9.3.0

--- a/setup.py
+++ b/setup.py
@@ -82,5 +82,5 @@ if __name__ == "__main__":
                 ("pm-symmetry = " "pymuonsuite.symmetry:main"),
             ]
         },
-        python_requires=">=3.7, <=3.11",
+        python_requires=">=3.8, <=3.11",
     )


### PR DESCRIPTION
In order to remove dependence on the outdated version 1.21 of numpy, need to drop support for python 3.7. Note that we have already done this for MuSpinSim.