### PR TITLE
Bump GitHub Actions upload-artifact@v6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,6 @@ jobs:
         run: |
           python -m pip install build
           python -m build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v6
         with:
           path: dist/*

--- a/.github/workflows/citation-cff.yml
+++ b/.github/workflows/citation-cff.yml
@@ -27,7 +27,7 @@ jobs:
         uses: dieghernan/cff-validator@main
 
       # Upload artifact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: citation-cff-errors


### PR DESCRIPTION
This doesn't run on the PR CI, but is failing on main: https://github.com/muon-spectroscopy-computational-project/pymuon-suite/actions/runs/21522580059/job/62017576325

v2/v3 was deprecated back in 2024

Closes #99 